### PR TITLE
Add requirements and settings for dev environment.

### DIFF
--- a/ponyconf/settings_dev.py
+++ b/ponyconf/settings_dev.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from django.utils import six
+
+from ponyconf.settings import *
+
+
+DEBUG = True
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+INSTALLED_APPS += (
+    'debug_toolbar',
+    'django_extensions',
+)
+
+INTERNAL_IPS = ('127.0.0.1',)  # Used by app debug_toolbar
+
+EMAIL_HOST = 'localhost'
+EMAIL_PORT = 1025
+
+TIME_ZONE = 'Europe/Paris'
+LANGUAGE_CODE = 'fr-FR'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 django<1.11
+
 django-autoslug
 django-bootstrap3
 django-bower
 django-registration-redux
 django-select2
 django-avatar
--e git://github.com/Nim65s/django-YummyEmailOrUsernameInsensitiveAuth.git#egg=django-yeouia
 
+-e git://github.com/Nim65s/django-YummyEmailOrUsernameInsensitiveAuth.git#egg=django-yeouia

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+
+ipython
+
+django-debug-toolbar
+django-extensions


### PR DESCRIPTION
J'ai ajouté un requirements et un settings pour les dev, en ajoutant la django-debug-toolbar et django-extensions. 

Je ne voulais pas trop faire de grosses modifications, alors j'ai fait simple comparé à ce que je vois à mon taf, à savoir un dossier requirements contenant base.txt, prod.txt, dev.txt et test.txt. Il y a un [super article sur le blog de miximum dans lequel j'avais aussi lu ça](https://www.miximum.fr/blog/checklist-bonnes-pratiques-django/).